### PR TITLE
Some Object tweaks and struct GAppInfo

### DIFF
--- a/glib-sys/src/lib.rs
+++ b/glib-sys/src/lib.rs
@@ -25,6 +25,9 @@ pub type GCallback = extern "C" fn();
 pub type GClosureNotify = extern "C" fn(data: gpointer, closure: gpointer);
 
 #[repr(C)]
+pub struct GAppInfo;
+
+#[repr(C)]
 pub struct GValue {
     type_: GType,
     data: [size_t; 2],
@@ -181,7 +184,10 @@ extern "C" {
     pub fn g_list_position                (list: *mut GList, link_: GList) -> c_int;
     // pub fn g_slist_index                   (list: *GSList, data: *c_void) -> c_int;
 
-
+    //=========================================================================
+    // GAppInfo
+    //=========================================================================
+    pub fn g_app_info_get_type            () -> GType;
 
     //=========================================================================
     // GError

--- a/src/app_info.rs
+++ b/src/app_info.rs
@@ -1,0 +1,23 @@
+// Copyright 2013-2015, The Rust-GNOME Project Developers.
+// See the COPYRIGHT file at the top-level directory of this distribution.
+// Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
+
+use ffi;
+use object::{GenericObject, Upcast};
+use translate::*;
+use types;
+
+pub type AppInfo = GenericObject<ffi::GAppInfo>;
+
+impl types::StaticType for AppInfo {
+    #[inline]
+    fn static_type() -> types::Type {
+        unsafe { from_glib(ffi::g_app_info_get_type()) }
+    }
+}
+
+pub trait AppInfoExt {
+}
+
+impl<O: Upcast<AppInfo>> AppInfoExt for O {
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub use glib_ffi as ffi;
 
 use libc::c_char;
 
+pub use self::app_info::AppInfo;
 pub use self::list::{List, Elem, RevElem};
 pub use self::slist::{SList, SElem};
 pub use self::glib_container::GlibContainer;
@@ -24,6 +25,7 @@ pub use self::value::{Value, ValuePublic};
 pub use types::Type;
 pub use self::date::{TimeVal, Time, Date, Year, Month, Weekday, Day};
 
+mod app_info;
 mod list;
 mod slist;
 pub mod glib_container;

--- a/src/object.rs
+++ b/src/object.rs
@@ -134,25 +134,6 @@ impl<'a, T, W: Wrapper<GlibType = T>> ToGlibPtr<'a, *mut T> for &'a W {
     }
 }
 
-impl<'a, T, W: Wrapper<GlibType = T>> ToGlibPtr<'a, *mut T> for Option<&'a W> {
-    type Storage = Option<&'a Ref>;
-
-    #[inline]
-    fn to_glib_none(&self) -> Stash<'a, *mut T, Option<&'a W>> {
-        if let Some(ref s) = *self {
-            Stash(s.as_ref().to_glib_none() as *mut _, Some(s.as_ref()))
-        }
-        else {
-            Stash(ptr::null_mut(), None)
-        }
-    }
-
-    #[inline]
-    fn to_glib_full(&self) -> *mut T {
-        self.as_ref().map_or(ptr::null_mut(), |s| s.as_ref().to_glib_full() as *mut _)
-    }
-}
-
 impl <T: Wrapper> FromGlibPtr<*mut <T as Wrapper>::GlibType> for T {
     #[inline]
     unsafe fn from_glib_none(ptr: *mut <T as Wrapper>::GlibType) -> Self {

--- a/src/object.rs
+++ b/src/object.rs
@@ -230,6 +230,7 @@ impl Wrapper for Object {
 }
 
 impl StaticType for Object {
+    #[inline]
     fn static_type() -> Type { Type::BaseObject }
 }
 
@@ -238,3 +239,26 @@ pub trait ObjectExt {
 
 impl<T: Upcast<Object>> ObjectExt for T {
 }
+
+/// The crate-local generic type for `GObject` descendants in GLib.
+#[derive(Debug)]
+pub struct GenericObject<T>(Ref, PhantomData<T>);
+
+impl<T> Wrapper for GenericObject<T> where GenericObject<T>: StaticType {
+    type GlibType = T;
+    #[inline]
+    unsafe fn wrap(r: Ref) -> GenericObject<T> { GenericObject(r, PhantomData) }
+    #[inline]
+    fn as_ref(&self) -> &Ref { &self.0 }
+    #[inline]
+    fn unwrap(self) -> Ref { self.0 }
+}
+
+impl<T> Clone for GenericObject<T> {
+    #[inline]
+    fn clone(&self) -> GenericObject<T> {
+        GenericObject(self.0.clone(), PhantomData)
+    }
+}
+
+unsafe impl<T> Upcast<Object> for GenericObject<T> where GenericObject<T>: StaticType { }

--- a/src/object.rs
+++ b/src/object.rs
@@ -233,6 +233,8 @@ impl StaticType for Object {
     fn static_type() -> Type { Type::BaseObject }
 }
 
-pub trait ObjectTrait { }
+pub trait ObjectExt {
+}
 
-impl<T: Upcast<Object>> ObjectTrait for T { }
+impl<T: Upcast<Object>> ObjectExt for T {
+}


### PR DESCRIPTION
This can come in early, no need to wait for GTK to be finished.
Also some glib improvements (populate `ObjectExt` and `AppInfoExt`) could be done independently.