### PR TITLE
Early steps toward supporting lgpl-docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,13 +83,18 @@ script:
     make regen_check;
     fi
   - if ! [ "$ARM" == "1" ]; then
-    cargo doc --features "dox";
+    cargo doc --features "dox,embed-lgpl-docs";
     fi
   - if ! [ "$ARM" == "1" ]; then
     cargo test --features "$FEATURES";
     fi
   - if [ "$ARM" == "1" ]; then
     PKG_CONFIG_ALLOW_CROSS=1 cargo build --features "$FEATURES" $OTHER_TARGET;
+    fi
+  - if ! [ "$ARM" == "1" ]; then
+    cargo build --features "$FEATURES,embed-lgpl-docs";
+    cargo build --features "$FEATURES,purge-lgpl-docs";
+    git diff -R --exit-code;
     fi
   - rustc --version
   - python3 clone_tests/clone_compilation_errors.py

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ version = "0.9.3"
 keywords = ["glib", "gtk-rs", "gnome", "GUI"]
 repository = "https://github.com/gtk-rs/glib"
 license = "MIT"
+build = "build.rs"
 exclude = [
     "gir-files/*",
 ]
@@ -47,6 +48,13 @@ v2_56 = ["v2_54", "glib-sys/v2_56"]
 v2_58 = ["v2_56", "glib-sys/v2_58"]
 v2_60 = ["v2_58", "glib-sys/v2_60"]
 dox = ["glib-sys/dox", "gobject-sys/dox"]
+purge-lgpl-docs = ["gtk-rs-lgpl-docs"]
+embed-lgpl-docs = ["gtk-rs-lgpl-docs"]
 
 [package.metadata.docs.rs]
-features = ["dox"]
+features = ["dox", "embed-lgpl-docs"]
+
+[build-dependencies.gtk-rs-lgpl-docs]
+version = "0.1.3"
+optional = true
+git = "https://github.com/gtk-rs/lgpl-docs"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,53 @@
+fn main() {
+    manage_docs();
+}
+
+#[cfg(any(feature = "embed-lgpl-docs", feature = "purge-lgpl-docs"))]
+fn manage_docs() {
+    extern crate lgpl_docs;
+    const PATH: &str = "src";
+    const IGNORES: &[&str] = &[
+        "lib.rs",
+        "prelude.rs",
+        "signal.rs",
+        "boxed.rs",
+        "byte_array.rs",
+        "bytes.rs",
+        "char.rs",
+        "clone.rs",
+        "enums.rs",
+        "error.rs",
+        "gobject/mod.rs",
+        "log.rs",
+        "main_context.rs",
+        "main_context_channel.rs",
+        "main_context_futures.rs",
+        "object.rs",
+        "send_unique.rs",
+        "shared.rs",
+        "source.rs",
+        "source_futures.rs",
+        "string.rs",
+        "subclass/boxed.rs",
+        "subclass/interface.rs",
+        "subclass/mod.rs",
+        "subclass/object.rs",
+        "subclass/simple.rs",
+        "subclass/types.rs",
+        "translate.rs",
+        "types.rs",
+        "utils.rs",
+        "value.rs",
+        "variant.rs",
+        "variant_dict.rs",
+        "variant_type.rs",
+        "wrapper.rs",
+    ];
+    lgpl_docs::purge(PATH, IGNORES);
+    if cfg!(feature = "embed-lgpl-docs") {
+        lgpl_docs::embed(lgpl_docs::Library::Glib, PATH, IGNORES);
+    }
+}
+
+#[cfg(not(any(feature = "embed-lgpl-docs", feature = "purge-lgpl-docs")))]
+fn manage_docs() {}


### PR DESCRIPTION
This PR covers the early steps of supporting the lgpl-docs repository in glib.

Unfortunately there is a lot of files currently put in the ignore list, though this does mean we import at least some docs into the autogenerated-from-gir code.  Further work will be needed to work out what can be transformed from existing docs into lgpl-docs content, versus what needs to remain ignored.