### PR TITLE
Fix double registration of GEnums

### DIFF
--- a/glib-macros/src/genum_derive.rs
+++ b/glib-macros/src/genum_derive.rs
@@ -165,7 +165,12 @@ pub fn impl_genum(input: &syn::DeriveInput) -> TokenStream {
 
                 let name = std::ffi::CString::new(#gtype_name).expect("CString::new failed");
                 unsafe {
-                    let type_ = #crate_ident::gobject_sys::g_enum_register_static(name.as_ptr(), VALUES.as_ptr());
+                    // Lookup the type ID or return 0 if it has not yet been registered under the specific name
+                    let mut type_ = #crate_ident::gobject_sys::g_type_from_name(name.as_pr());
+                    if type_ == 0 {
+                        // Register the type ONLY if not done before
+                        type_ = #crate_ident::gobject_sys::g_enum_register_static(name.as_ptr(), VALUES.as_ptr());
+                    }
                     TYPE = #crate_ident::translate::from_glib(type_);
                 }
             });


### PR DESCRIPTION
The `GEnum` derive macro did not check whether an enum exists before registering it, leading to a panic if the same enum is registered twice:

```
GLib-GObject-WARNING **: 08:04:50.392: cannot register existing type 'EnumName'
thread '<unnamed>' panicked at 'assertion failed: `(left != right)`
  left: `<invalid>`,
  right: `<invalid>`', /path/to/source.rs
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This PR makes sure that enums are only registered if `gobject_sys::g_type_from_name` returns `0`.